### PR TITLE
Resolve circular dependency between org.eclipse.mylyn.monitor.* and org.eclipse.mylyn.context.*

### DIFF
--- a/org.eclipse.mylyn.cdt.ui/src/org/eclipse/mylyn/internal/cdt/ui/CDTEditorMonitor.java
+++ b/org.eclipse.mylyn.cdt.ui/src/org/eclipse/mylyn/internal/cdt/ui/CDTEditorMonitor.java
@@ -21,14 +21,14 @@ import org.eclipse.cdt.internal.ui.actions.SelectionConverter;
 import org.eclipse.cdt.internal.ui.editor.CEditor;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.StructuredSelection;
-import org.eclipse.mylyn.monitor.ui.AbstractUserInteractionMonitor;
+import org.eclipse.mylyn.context.core.AbstractContextInteractionMonitor;
 import org.eclipse.ui.IWorkbenchPart;
 
 /**
  * @author Mik Kersten
  * @author Jeff Johnston
  */
-public class CDTEditorMonitor extends AbstractUserInteractionMonitor {
+public class CDTEditorMonitor extends AbstractContextInteractionMonitor {
 
 	protected ICElement lastSelectedElement = null;
 

--- a/org.eclipse.mylyn.context.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.mylyn.context.core/META-INF/MANIFEST.MF
@@ -6,8 +6,11 @@ Bundle-Version: 3.26.0.qualifier
 Bundle-Activator: org.eclipse.mylyn.internal.context.core.ContextCorePlugin
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime,
+ org.eclipse.ui,
  org.eclipse.mylyn.commons.core;bundle-version="[3.8.0,4.0.0)",
- org.eclipse.mylyn.monitor.core;bundle-version="[3.8.0,4.0.0)"
+ org.eclipse.mylyn.monitor.core;bundle-version="[3.8.0,4.0.0)",
+ org.eclipse.mylyn.monitor.ui,
+ org.eclipse.mylyn.commons.context
 Import-Package: org.apache.commons.io;version="[1.4.0,3.0.0)"
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %Bundle-Vendor

--- a/org.eclipse.mylyn.context.core/plugin.xml
+++ b/org.eclipse.mylyn.context.core/plugin.xml
@@ -19,4 +19,10 @@
    <extension-point id="internalBridges" name="Internal Bridges" schema="schema/internalBridges.exsd"/>
    <extension-point id="relationProviders" name="relationProviders" schema="schema/relationProviders.exsd"/>
    <extension-point id="strategies" name="strategies" schema="schema/strategies.exsd"/>
+   <extension
+         point="org.eclipse.mylyn.commons.context.startup">
+      <startup
+            class="org.eclipse.mylyn.internal.context.core.ContextStarter">
+      </startup>
+   </extension>
 </plugin>

--- a/org.eclipse.mylyn.context.core/src/org/eclipse/mylyn/context/core/AbstractContextInteractionMonitor.java
+++ b/org.eclipse.mylyn.context.core/src/org/eclipse/mylyn/context/core/AbstractContextInteractionMonitor.java
@@ -1,0 +1,137 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Frank Becker and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Frank Becker - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.mylyn.context.core;
+
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.mylyn.internal.monitor.ui.IMonitoredWindow;
+import org.eclipse.mylyn.internal.monitor.ui.MonitorUiPlugin;
+import org.eclipse.mylyn.monitor.core.InteractionEvent;
+import org.eclipse.mylyn.monitor.ui.AbstractUserInteractionMonitor;
+import org.eclipse.ui.IWorkbenchPart;
+import org.eclipse.ui.IWorkbenchWindow;
+
+/**
+ * @since 3.26
+ */
+public abstract class AbstractContextInteractionMonitor extends AbstractUserInteractionMonitor {
+
+	@Override
+	public void selectionChanged(IWorkbenchPart part, ISelection selection) {
+		if (part.getSite() != null && part.getSite().getWorkbenchWindow() != null) {
+			IWorkbenchWindow window = part.getSite().getWorkbenchWindow();
+			if (window instanceof IMonitoredWindow && !((IMonitoredWindow) window).isMonitored()) {
+				return;
+			}
+		}
+		if (selection == null || selection.isEmpty()) {
+			return;
+		}
+		if (!ContextCore.getContextManager().isContextActive()) {
+			handleWorkbenchPartSelection(part, selection, false);
+		} else {
+			handleWorkbenchPartSelection(part, selection, true);
+		}
+	}
+
+	/**
+	 * Intended to be called back by subclasses.
+	 */
+	@Override
+	protected void handleNavigation(IWorkbenchPart part, Object targetElement, String kind,
+			boolean contributeToContext) {
+		handleNavigation(part.getSite().getId(), targetElement, kind, contributeToContext);
+	}
+
+	/**
+	 * Intended to be called back by subclasses. *
+	 *
+	 * @since 3.1
+	 */
+	@Override
+	protected void handleNavigation(String partId, Object targetElement, String kind, boolean contributeToContext) {
+		AbstractContextStructureBridge adapter = ContextCore.getStructureBridge(targetElement);
+		if (adapter.getContentType() != null) {
+			String handleIdentifier = adapter.getHandleIdentifier(targetElement);
+			InteractionEvent navigationEvent = new InteractionEvent(InteractionEvent.Kind.SELECTION,
+					adapter.getContentType(), handleIdentifier, partId, kind);
+			if (handleIdentifier != null && contributeToContext) {
+				ContextCore.getContextManager().processInteractionEvent(navigationEvent);
+			}
+			MonitorUiPlugin.getDefault().notifyInteractionObserved(navigationEvent);
+		}
+	}
+
+	/**
+	 * Intended to be called back by subclasses.
+	 *
+	 * @since 3.1
+	 */
+	@Override
+	protected void handleElementEdit(String partId, Object selectedElement, boolean contributeToContext) {
+		if (selectedElement == null) {
+			return;
+		}
+		AbstractContextStructureBridge bridge = ContextCore.getStructureBridge(selectedElement);
+		String handleIdentifier = bridge.getHandleIdentifier(selectedElement);
+		InteractionEvent editEvent = new InteractionEvent(InteractionEvent.Kind.EDIT, bridge.getContentType(),
+				handleIdentifier, partId);
+		if (handleIdentifier != null && contributeToContext) {
+			ContextCore.getContextManager().processInteractionEvent(editEvent);
+		}
+		MonitorUiPlugin.getDefault().notifyInteractionObserved(editEvent);
+	}
+
+	/**
+	 * Intended to be called back by subclasses. *
+	 *
+	 * @since 3.1
+	 */
+	@Override
+	protected InteractionEvent handleElementSelection(String partId, Object selectedElement,
+			boolean contributeToContext) {
+		if (selectedElement == null || selectedElement.equals(lastSelectedElement)) {
+			return null;
+		}
+		AbstractContextStructureBridge bridge = ContextCore.getStructureBridge(selectedElement);
+		String handleIdentifier = bridge.getHandleIdentifier(selectedElement);
+		InteractionEvent selectionEvent;
+		if (bridge.getContentType() != null) {
+			selectionEvent = new InteractionEvent(InteractionEvent.Kind.SELECTION, bridge.getContentType(),
+					handleIdentifier, partId);
+		} else {
+			selectionEvent = new InteractionEvent(InteractionEvent.Kind.SELECTION, null, null, partId);
+		}
+		if (handleIdentifier != null && contributeToContext) {
+			ContextCore.getContextManager().processInteractionEvent(selectionEvent);
+		}
+		MonitorUiPlugin.getDefault().notifyInteractionObserved(selectionEvent);
+		return selectionEvent;
+	}
+
+	/**
+	 * Intended to be called back by subclasses.
+	 */
+	@Override
+	protected InteractionEvent handleElementSelection(IWorkbenchPart part, Object selectedElement,
+			boolean contributeToContext) {
+		return handleElementSelection(part.getSite().getId(), selectedElement, contributeToContext);
+	}
+
+	/**
+	 * Intended to be called back by subclasses.
+	 */
+	@Override
+	protected void handleElementEdit(IWorkbenchPart part, Object selectedElement, boolean contributeToContext) {
+		handleElementEdit(part.getSite().getId(), selectedElement, contributeToContext);
+	}
+
+}

--- a/org.eclipse.mylyn.context.core/src/org/eclipse/mylyn/internal/context/core/ContextStarter.java
+++ b/org.eclipse.mylyn.context.core/src/org/eclipse/mylyn/internal/context/core/ContextStarter.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Frank Becker and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Frank Becker - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.mylyn.internal.context.core;
+
+import org.eclipse.mylyn.common.context.IContextStarter;
+import org.eclipse.mylyn.context.core.ContextCore;
+import org.eclipse.mylyn.monitor.core.InteractionEvent;
+
+public class ContextStarter implements IContextStarter {
+
+	@Override
+	public void processActivityMetaContextEvent(InteractionEvent event) {
+		ContextCorePlugin.getContextManager().processActivityMetaContextEvent(event);
+	}
+
+	@Override
+	public String getActiveContextHandleIdentifier() {
+		if (ContextCore.getContextManager().getActiveContext().getHandleIdentifier() != null) {
+			return ContextCore.getContextManager().getActiveContext().getHandleIdentifier();
+		}
+		return null;
+	}
+
+}

--- a/org.eclipse.mylyn.context.core/src/org/eclipse/mylyn/internal/context/core/InteractionContextManager.java
+++ b/org.eclipse.mylyn.context.core/src/org/eclipse/mylyn/internal/context/core/InteractionContextManager.java
@@ -39,6 +39,7 @@ import org.eclipse.core.runtime.SafeRunner;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.ILock;
 import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.mylyn.common.context.CommonInteractionContextManager;
 import org.eclipse.mylyn.commons.core.StatusHandler;
 import org.eclipse.mylyn.context.core.AbstractContextListener;
 import org.eclipse.mylyn.context.core.AbstractContextStructureBridge;
@@ -84,27 +85,13 @@ public class InteractionContextManager implements IInteractionContextManager {
 
 	public static final String ACTIVITY_STRUCTUREKIND_ACTIVATION = "activation"; //$NON-NLS-1$
 
-	public static final String ACTIVITY_STRUCTUREKIND_TIMING = "timing"; //$NON-NLS-1$
-
-	public static final String ACTIVITY_STRUCTUREKIND_WORKINGSET = "workingset"; //$NON-NLS-1$
-
 	public static final String ACTIVITY_STRUCTUREKIND_LIFECYCLE = "lifecycle"; //$NON-NLS-1$
 
-	public static final String ACTIVITY_ORIGINID_USER = "user"; //$NON-NLS-1$
-
 	public static final String ACTIVITY_ORIGINID_OS = "os"; //$NON-NLS-1$
-
-	public static final String ACTIVITY_ORIGINID_WORKBENCH = "org.eclipse.ui.workbench"; //$NON-NLS-1$
-
-	public static final String ACTIVITY_HANDLE_NONE = "none"; //$NON-NLS-1$
 
 	public static final String ACTIVITY_DELTA_STOPPED = "stopped"; //$NON-NLS-1$
 
 	public static final String ACTIVITY_DELTA_STARTED = "started"; //$NON-NLS-1$
-
-	public static final String ACTIVITY_DELTA_REMOVED = "removed"; //$NON-NLS-1$
-
-	public static final String ACTIVITY_DELTA_ADDED = "added"; //$NON-NLS-1$
 
 	public static final String ACTIVITY_DELTA_ACTIVATED = "activated"; //$NON-NLS-1$
 
@@ -329,7 +316,7 @@ public class InteractionContextManager implements IInteractionContextManager {
 		for (InteractionEvent event : context.getInteractionHistory()) {
 
 			if (event.getKind().equals(InteractionEvent.Kind.ATTENTION)
-					&& event.getDelta().equals(InteractionContextManager.ACTIVITY_DELTA_ADDED)) {
+					&& event.getDelta().equals(CommonInteractionContextManager.ACTIVITY_DELTA_ADDED)) {
 				if (event.getStructureHandle() == null || event.getStructureHandle().equals("")) { //$NON-NLS-1$
 					continue;
 				}
@@ -474,7 +461,7 @@ public class InteractionContextManager implements IInteractionContextManager {
 			if (!activationHistorySuppressed) {
 				processActivityMetaContextEvent(new InteractionEvent(InteractionEvent.Kind.COMMAND,
 						InteractionContextManager.ACTIVITY_STRUCTUREKIND_ACTIVATION, handleIdentifier,
-						InteractionContextManager.ACTIVITY_ORIGINID_WORKBENCH, null,
+						CommonInteractionContextManager.ACTIVITY_ORIGINID_WORKBENCH, null,
 						InteractionContextManager.ACTIVITY_DELTA_DEACTIVATED, 1f));
 			}
 //			saveActivityMetaContext();
@@ -698,7 +685,7 @@ public class InteractionContextManager implements IInteractionContextManager {
 		if (!activationHistorySuppressed) {
 			processActivityMetaContextEvent(new InteractionEvent(InteractionEvent.Kind.COMMAND,
 					InteractionContextManager.ACTIVITY_STRUCTUREKIND_ACTIVATION, context.getHandleIdentifier(),
-					InteractionContextManager.ACTIVITY_ORIGINID_WORKBENCH, null,
+					CommonInteractionContextManager.ACTIVITY_ORIGINID_WORKBENCH, null,
 					InteractionContextManager.ACTIVITY_DELTA_ACTIVATED, 1f));
 		}
 

--- a/org.eclipse.mylyn.context.core/src/org/eclipse/mylyn/internal/context/core/LegacyActivityAdaptor.java
+++ b/org.eclipse.mylyn.context.core/src/org/eclipse/mylyn/internal/context/core/LegacyActivityAdaptor.java
@@ -14,6 +14,7 @@ package org.eclipse.mylyn.internal.context.core;
 
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
+import org.eclipse.mylyn.common.context.CommonInteractionContextManager;
 import org.eclipse.mylyn.commons.core.StatusHandler;
 import org.eclipse.mylyn.monitor.core.InteractionEvent;
 
@@ -41,9 +42,10 @@ public class LegacyActivityAdaptor {
 						&& event.getStructureHandle().equals(LEGACY_HANDLE_ATTENTION)) {
 					if (currentTask != null && !currentTask.equals("")) { //$NON-NLS-1$
 						return new InteractionEvent(InteractionEvent.Kind.ATTENTION,
-								InteractionContextManager.ACTIVITY_STRUCTUREKIND_TIMING, currentTask,
-								InteractionContextManager.ACTIVITY_ORIGINID_WORKBENCH, null,
-								InteractionContextManager.ACTIVITY_DELTA_ADDED, 1f, event.getDate(), event.getEndDate());
+								CommonInteractionContextManager.ACTIVITY_STRUCTUREKIND_TIMING, currentTask,
+								CommonInteractionContextManager.ACTIVITY_ORIGINID_WORKBENCH, null,
+								CommonInteractionContextManager.ACTIVITY_DELTA_ADDED, 1f, event.getDate(),
+								event.getEndDate());
 					} else if (currentTask == null) {
 						// bogus event remove.
 						return null;

--- a/org.eclipse.mylyn.context.tasks.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.mylyn.context.tasks.tests/META-INF/MANIFEST.MF
@@ -26,6 +26,7 @@ Require-Bundle: org.junit;bundle-version="4.8.2",
  org.eclipse.mylyn.tests.util,
  org.eclipse.ui.editors,
  org.eclipse.ui.forms,
- com.google.guava;bundle-version="[21.0.0,22.0.0)"
+ com.google.guava;bundle-version="[21.0.0,22.0.0)",
+ org.eclipse.mylyn.commons.context
 Export-Package: org.eclipse.mylyn.context.tasks.tests;x-internal:=true
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/org.eclipse.mylyn.context.tasks.tests/src/org/eclipse/mylyn/context/tasks/tests/RefactorRepositoryUrlOperationTest.java
+++ b/org.eclipse.mylyn.context.tasks.tests/src/org/eclipse/mylyn/context/tasks/tests/RefactorRepositoryUrlOperationTest.java
@@ -14,12 +14,10 @@ package org.eclipse.mylyn.context.tasks.tests;
 
 import java.util.Calendar;
 
-import junit.framework.TestCase;
-
 import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.mylyn.common.context.CommonInteractionContextManager;
 import org.eclipse.mylyn.internal.context.core.ContextCorePlugin;
 import org.eclipse.mylyn.internal.context.core.InteractionContext;
-import org.eclipse.mylyn.internal.context.core.InteractionContextManager;
 import org.eclipse.mylyn.internal.tasks.core.AbstractTask;
 import org.eclipse.mylyn.internal.tasks.core.RepositoryQuery;
 import org.eclipse.mylyn.internal.tasks.core.TaskList;
@@ -32,6 +30,8 @@ import org.eclipse.mylyn.tasks.tests.connector.MockRepositoryQuery;
 import org.eclipse.mylyn.tasks.tests.connector.MockTask;
 import org.junit.Before;
 import org.junit.Test;
+
+import junit.framework.TestCase;
 
 /**
  * @author Robert Elves
@@ -88,16 +88,16 @@ public class RefactorRepositoryUrlOperationTest extends TestCase {
 		InteractionContext metaContext = ContextCorePlugin.getContextManager().getActivityMetaContext();
 		assertEquals(0, metaContext.getInteractionHistory().size());
 
-		ContextCorePlugin.getContextManager().processActivityMetaContextEvent(
-				new InteractionEvent(InteractionEvent.Kind.ATTENTION,
-						InteractionContextManager.ACTIVITY_STRUCTUREKIND_TIMING, task1.getHandleIdentifier(), "origin",
-						null, InteractionContextManager.ACTIVITY_DELTA_ADDED, 1f, startDate.getTime(),
+		ContextCorePlugin.getContextManager()
+				.processActivityMetaContextEvent(new InteractionEvent(InteractionEvent.Kind.ATTENTION,
+						CommonInteractionContextManager.ACTIVITY_STRUCTUREKIND_TIMING, task1.getHandleIdentifier(),
+						"origin", null, CommonInteractionContextManager.ACTIVITY_DELTA_ADDED, 1f, startDate.getTime(),
 						endDate.getTime()));
 
-		ContextCorePlugin.getContextManager().processActivityMetaContextEvent(
-				new InteractionEvent(InteractionEvent.Kind.ATTENTION,
-						InteractionContextManager.ACTIVITY_STRUCTUREKIND_TIMING, task2.getHandleIdentifier(), "origin",
-						null, InteractionContextManager.ACTIVITY_DELTA_ADDED, 1f, startDate2.getTime(),
+		ContextCorePlugin.getContextManager()
+				.processActivityMetaContextEvent(new InteractionEvent(InteractionEvent.Kind.ATTENTION,
+						CommonInteractionContextManager.ACTIVITY_STRUCTUREKIND_TIMING, task2.getHandleIdentifier(),
+						"origin", null, CommonInteractionContextManager.ACTIVITY_DELTA_ADDED, 1f, startDate2.getTime(),
 						endDate2.getTime()));
 
 		assertEquals(2, metaContext.getInteractionHistory().size());

--- a/org.eclipse.mylyn.context.tasks.tests/src/org/eclipse/mylyn/context/tasks/tests/TaskActivityTimingTest.java
+++ b/org.eclipse.mylyn.context.tasks.tests/src/org/eclipse/mylyn/context/tasks/tests/TaskActivityTimingTest.java
@@ -20,8 +20,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Set;
 
-import junit.framework.TestCase;
-
+import org.eclipse.mylyn.common.context.CommonInteractionContextManager;
 import org.eclipse.mylyn.commons.sdk.util.CommonTestUtil;
 import org.eclipse.mylyn.internal.context.core.ContextCorePlugin;
 import org.eclipse.mylyn.internal.context.core.InteractionContext;
@@ -42,6 +41,8 @@ import org.eclipse.mylyn.monitor.core.InteractionEvent;
 import org.eclipse.mylyn.tasks.core.ITask;
 import org.eclipse.mylyn.tasks.ui.TasksUi;
 import org.eclipse.mylyn.tests.util.TestFixture;
+
+import junit.framework.TestCase;
 
 /**
  * @author Rob Elves
@@ -135,11 +136,13 @@ public class TaskActivityTimingTest extends TestCase {
 		end2.add(Calendar.HOUR_OF_DAY, 2);
 
 		InteractionEvent event1 = new InteractionEvent(InteractionEvent.Kind.ATTENTION,
-				InteractionContextManager.ACTIVITY_STRUCTUREKIND_WORKINGSET, "none", "originId", "navigatedRelation",
-				InteractionContextManager.ACTIVITY_DELTA_ADDED, 2f, start.getTime(), end.getTime());
+				CommonInteractionContextManager.ACTIVITY_STRUCTUREKIND_WORKINGSET, "none", "originId",
+				"navigatedRelation", CommonInteractionContextManager.ACTIVITY_DELTA_ADDED, 2f, start.getTime(),
+				end.getTime());
 		InteractionEvent event2 = new InteractionEvent(InteractionEvent.Kind.ATTENTION,
-				InteractionContextManager.ACTIVITY_STRUCTUREKIND_WORKINGSET, "none", "originId", "navigatedRelation",
-				InteractionContextManager.ACTIVITY_DELTA_ADDED, 2f, start2.getTime(), end2.getTime());
+				CommonInteractionContextManager.ACTIVITY_STRUCTUREKIND_WORKINGSET, "none", "originId",
+				"navigatedRelation", CommonInteractionContextManager.ACTIVITY_DELTA_ADDED, 2f, start2.getTime(),
+				end2.getTime());
 
 		activityMonitor.parseInteractionEvent(event1, false);
 		activityMonitor.parseInteractionEvent(event2, false);
@@ -162,11 +165,13 @@ public class TaskActivityTimingTest extends TestCase {
 		end2.add(Calendar.HOUR_OF_DAY, 2);
 
 		InteractionEvent event1 = new InteractionEvent(InteractionEvent.Kind.ATTENTION,
-				InteractionContextManager.ACTIVITY_STRUCTUREKIND_WORKINGSET, "set 1", "originId", "navigatedRelation",
-				InteractionContextManager.ACTIVITY_DELTA_ADDED, 2f, start.getTime(), end.getTime());
+				CommonInteractionContextManager.ACTIVITY_STRUCTUREKIND_WORKINGSET, "set 1", "originId",
+				"navigatedRelation", CommonInteractionContextManager.ACTIVITY_DELTA_ADDED, 2f, start.getTime(),
+				end.getTime());
 		InteractionEvent event2 = new InteractionEvent(InteractionEvent.Kind.ATTENTION,
-				InteractionContextManager.ACTIVITY_STRUCTUREKIND_WORKINGSET, "set 2", "originId", "navigatedRelation",
-				InteractionContextManager.ACTIVITY_DELTA_ADDED, 2f, start2.getTime(), end2.getTime());
+				CommonInteractionContextManager.ACTIVITY_STRUCTUREKIND_WORKINGSET, "set 2", "originId",
+				"navigatedRelation", CommonInteractionContextManager.ACTIVITY_DELTA_ADDED, 2f, start2.getTime(),
+				end2.getTime());
 
 		activityMonitor.parseInteractionEvent(event1, false);
 		activityMonitor.parseInteractionEvent(event2, false);
@@ -198,10 +203,10 @@ public class TaskActivityTimingTest extends TestCase {
 
 		InteractionEvent event1 = new InteractionEvent(InteractionEvent.Kind.ATTENTION, "structureKind",
 				task1.getHandleIdentifier(), "originId", "navigatedRelation",
-				InteractionContextManager.ACTIVITY_DELTA_ADDED, 2f, start.getTime(), end.getTime());
+				CommonInteractionContextManager.ACTIVITY_DELTA_ADDED, 2f, start.getTime(), end.getTime());
 		InteractionEvent event2 = new InteractionEvent(InteractionEvent.Kind.ATTENTION, "structureKind",
 				task1.getHandleIdentifier(), "originId", "navigatedRelation",
-				InteractionContextManager.ACTIVITY_DELTA_ADDED, 2f, start2.getTime(), end2.getTime());
+				CommonInteractionContextManager.ACTIVITY_DELTA_ADDED, 2f, start2.getTime(), end2.getTime());
 
 		activityMonitor.parseInteractionEvent(event1, false);
 		activityMonitor.parseInteractionEvent(event2, false);
@@ -237,10 +242,10 @@ public class TaskActivityTimingTest extends TestCase {
 
 		InteractionEvent event1 = new InteractionEvent(InteractionEvent.Kind.ATTENTION, "structureKind",
 				task1.getHandleIdentifier(), "originId", "navigatedRelation",
-				InteractionContextManager.ACTIVITY_DELTA_ADDED, 2f, start.getTime(), end.getTime());
+				CommonInteractionContextManager.ACTIVITY_DELTA_ADDED, 2f, start.getTime(), end.getTime());
 		InteractionEvent event2 = new InteractionEvent(InteractionEvent.Kind.ATTENTION, "structureKind",
 				task1.getHandleIdentifier(), "originId", "navigatedRelation",
-				InteractionContextManager.ACTIVITY_DELTA_ADDED, 2f, start2.getTime(), end2.getTime());
+				CommonInteractionContextManager.ACTIVITY_DELTA_ADDED, 2f, start2.getTime(), end2.getTime());
 
 		ContextCorePlugin.getContextManager().getActivityMetaContext().parseEvent(event1);
 		activityMonitor.parseInteractionEvent(event1, false);
@@ -371,10 +376,10 @@ public class TaskActivityTimingTest extends TestCase {
 
 		InteractionEvent event1 = new InteractionEvent(InteractionEvent.Kind.ATTENTION, "structureKind",
 				task1.getHandleIdentifier(), "originId", "navigatedRelation",
-				InteractionContextManager.ACTIVITY_DELTA_ADDED, 2f, end.getTime(), start.getTime());
+				CommonInteractionContextManager.ACTIVITY_DELTA_ADDED, 2f, end.getTime(), start.getTime());
 		InteractionEvent event2 = new InteractionEvent(InteractionEvent.Kind.ATTENTION, "structureKind",
 				task1.getHandleIdentifier(), "originId", "navigatedRelation",
-				InteractionContextManager.ACTIVITY_DELTA_ADDED, 2f, end2.getTime(), start2.getTime());
+				CommonInteractionContextManager.ACTIVITY_DELTA_ADDED, 2f, end2.getTime(), start2.getTime());
 
 		activityMonitor.parseInteractionEvent(event1, false);
 		activityMonitor.parseInteractionEvent(event2, false);
@@ -397,10 +402,10 @@ public class TaskActivityTimingTest extends TestCase {
 		end.add(Calendar.HOUR_OF_DAY, 2);
 
 		InteractionEvent event1 = new InteractionEvent(InteractionEvent.Kind.ATTENTION, "structureKind", null,
-				"originId", "navigatedRelation", InteractionContextManager.ACTIVITY_DELTA_ADDED, 2f, start.getTime(),
-				end.getTime());
-		InteractionEvent event2 = new InteractionEvent(InteractionEvent.Kind.ATTENTION, "structureKind", "",
-				"originId", "navigatedRelation", InteractionContextManager.ACTIVITY_DELTA_ADDED, 2f, start.getTime(),
+				"originId", "navigatedRelation", CommonInteractionContextManager.ACTIVITY_DELTA_ADDED, 2f,
+				start.getTime(), end.getTime());
+		InteractionEvent event2 = new InteractionEvent(InteractionEvent.Kind.ATTENTION, "structureKind", "", "originId",
+				"navigatedRelation", CommonInteractionContextManager.ACTIVITY_DELTA_ADDED, 2f, start.getTime(),
 				end.getTime());
 
 		activityMonitor.parseInteractionEvent(event1, false);
@@ -460,11 +465,11 @@ public class TaskActivityTimingTest extends TestCase {
 			endTime.add(Calendar.SECOND, -5);
 
 			InteractionEvent event1 = new InteractionEvent(InteractionEvent.Kind.SELECTION, "structureKind",
-					task1.getHandleIdentifier(), InteractionContextManager.ACTIVITY_ORIGINID_WORKBENCH,
+					task1.getHandleIdentifier(), CommonInteractionContextManager.ACTIVITY_ORIGINID_WORKBENCH,
 					"navigatedRelation", InteractionContextManager.ACTIVITY_DELTA_ACTIVATED, 2f,
 					startActiveTime.getTime(), startActiveTime.getTime());
 			InteractionEvent event2 = new InteractionEvent(InteractionEvent.Kind.SELECTION, "structureKind",
-					task1.getHandleIdentifier(), InteractionContextManager.ACTIVITY_ORIGINID_WORKBENCH,
+					task1.getHandleIdentifier(), CommonInteractionContextManager.ACTIVITY_ORIGINID_WORKBENCH,
 					"navigatedRelation", InteractionContextManager.ACTIVITY_DELTA_DEACTIVATED, 2f,
 					endActiveTime.getTime(), endActiveTime.getTime());
 
@@ -503,11 +508,11 @@ public class TaskActivityTimingTest extends TestCase {
 			endTime2.setTimeInMillis(endActiveTime2.getTimeInMillis() - 2000);
 
 			InteractionEvent event1 = new InteractionEvent(InteractionEvent.Kind.SELECTION, "structureKind",
-					task1.getHandleIdentifier(), InteractionContextManager.ACTIVITY_ORIGINID_WORKBENCH,
+					task1.getHandleIdentifier(), CommonInteractionContextManager.ACTIVITY_ORIGINID_WORKBENCH,
 					"navigatedRelation", InteractionContextManager.ACTIVITY_DELTA_ACTIVATED, 2f,
 					startActiveTime2.getTime(), startActiveTime2.getTime());
 			InteractionEvent event2 = new InteractionEvent(InteractionEvent.Kind.SELECTION, "structureKind",
-					task1.getHandleIdentifier(), InteractionContextManager.ACTIVITY_ORIGINID_WORKBENCH,
+					task1.getHandleIdentifier(), CommonInteractionContextManager.ACTIVITY_ORIGINID_WORKBENCH,
 					"navigatedRelation", InteractionContextManager.ACTIVITY_DELTA_DEACTIVATED, 2f,
 					endActiveTime2.getTime(), endActiveTime2.getTime());
 
@@ -922,7 +927,7 @@ public class TaskActivityTimingTest extends TestCase {
 		assertEquals(expectedTotalTime, TasksUiPlugin.getTaskActivityManager().getElapsedTime(task1));
 	}
 
-// DND: OLD ACTIVITY TESTS - Will be using to test activity report/view 
+// DND: OLD ACTIVITY TESTS - Will be using to test activity report/view
 //	public void testInterleavedActivation() {
 //
 //		AbstractTask task1 = new LocalTask("task 1", "Task 1");
@@ -1243,14 +1248,14 @@ public class TaskActivityTimingTest extends TestCase {
 		TasksUiPlugin.getTaskList().addTask(task2);
 
 		InteractionEvent event1 = new InteractionEvent(InteractionEvent.Kind.ATTENTION,
-				InteractionContextManager.ACTIVITY_STRUCTUREKIND_TIMING, task1.getHandleIdentifier(),
-				InteractionContextManager.ACTIVITY_ORIGINID_WORKBENCH, null,
-				InteractionContextManager.ACTIVITY_DELTA_ADDED, 2f, startDate.getTime(), endDate.getTime());
+				CommonInteractionContextManager.ACTIVITY_STRUCTUREKIND_TIMING, task1.getHandleIdentifier(),
+				CommonInteractionContextManager.ACTIVITY_ORIGINID_WORKBENCH, null,
+				CommonInteractionContextManager.ACTIVITY_DELTA_ADDED, 2f, startDate.getTime(), endDate.getTime());
 
 		InteractionEvent event2 = new InteractionEvent(InteractionEvent.Kind.ATTENTION,
-				InteractionContextManager.ACTIVITY_STRUCTUREKIND_TIMING, task2.getHandleIdentifier(),
-				InteractionContextManager.ACTIVITY_ORIGINID_WORKBENCH, null,
-				InteractionContextManager.ACTIVITY_DELTA_ADDED, 2f, startDate.getTime(), endDate.getTime());
+				CommonInteractionContextManager.ACTIVITY_STRUCTUREKIND_TIMING, task2.getHandleIdentifier(),
+				CommonInteractionContextManager.ACTIVITY_ORIGINID_WORKBENCH, null,
+				CommonInteractionContextManager.ACTIVITY_DELTA_ADDED, 2f, startDate.getTime(), endDate.getTime());
 
 		activityMonitor.parseInteractionEvent(event1, false);
 		activityMonitor.parseInteractionEvent(event2, false);
@@ -1288,8 +1293,8 @@ public class TaskActivityTimingTest extends TestCase {
 
 	private InteractionEvent createTimingEvent(Calendar startTime, Calendar endTime, String handle) {
 		return new InteractionEvent(InteractionEvent.Kind.ATTENTION,
-				InteractionContextManager.ACTIVITY_STRUCTUREKIND_TIMING, handle,
-				InteractionContextManager.ACTIVITY_ORIGINID_WORKBENCH, null,
-				InteractionContextManager.ACTIVITY_DELTA_ADDED, 1f, startTime.getTime(), endTime.getTime());
+				CommonInteractionContextManager.ACTIVITY_STRUCTUREKIND_TIMING, handle,
+				CommonInteractionContextManager.ACTIVITY_ORIGINID_WORKBENCH, null,
+				CommonInteractionContextManager.ACTIVITY_DELTA_ADDED, 1f, startTime.getTime(), endTime.getTime());
 	}
 }

--- a/org.eclipse.mylyn.context.tasks.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.mylyn.context.tasks.ui/META-INF/MANIFEST.MF
@@ -19,7 +19,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.mylyn.monitor.ui;bundle-version="3.8.0",
  org.eclipse.mylyn.tasks.core;bundle-version="3.8.0",
  org.eclipse.mylyn.tasks.ui;bundle-version="3.8.0",
- com.google.guava;bundle-version="[21.0.0,22.0.0)"
+ com.google.guava;bundle-version="[21.0.0,22.0.0)",
+ org.eclipse.mylyn.commons.context
 Bundle-Vendor: %Bundle-Vendor
 Export-Package: org.eclipse.mylyn.internal.context.tasks.ui;x-internal:=true,
  org.eclipse.mylyn.internal.context.tasks.ui.editors;x-internal:=true

--- a/org.eclipse.mylyn.context.tasks.ui/src/org/eclipse/mylyn/internal/context/tasks/ui/TaskActivityMonitor.java
+++ b/org.eclipse.mylyn.context.tasks.ui/src/org/eclipse/mylyn/internal/context/tasks/ui/TaskActivityMonitor.java
@@ -20,6 +20,7 @@ import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.mylyn.common.context.CommonInteractionContextManager;
 import org.eclipse.mylyn.commons.core.StatusHandler;
 import org.eclipse.mylyn.commons.workbench.WorkbenchUtil;
 import org.eclipse.mylyn.context.core.AbstractContextListener;
@@ -221,7 +222,7 @@ public class TaskActivityMonitor extends AbstractTaskActivityMonitor {
 				if ((event.getDelta().equals("added") || event.getDelta().equals("add"))) { //$NON-NLS-1$ //$NON-NLS-2$
 					if (event.getDate().getTime() > 0 && event.getEndDate().getTime() > 0) {
 						if (event.getStructureKind()
-								.equals(InteractionContextManager.ACTIVITY_STRUCTUREKIND_WORKINGSET)) {
+								.equals(CommonInteractionContextManager.ACTIVITY_STRUCTUREKIND_WORKINGSET)) {
 							taskActivityManager.addWorkingSetElapsedTime(event.getStructureHandle(), event.getDate(),
 									event.getEndDate());
 							if (!isReloading) {

--- a/org.eclipse.mylyn.context.tests/src/org/eclipse/mylyn/context/tests/support/TestMonitor.java
+++ b/org.eclipse.mylyn.context.tests/src/org/eclipse/mylyn/context/tests/support/TestMonitor.java
@@ -18,15 +18,15 @@ import java.util.List;
 import org.eclipse.core.internal.resources.File;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jface.viewers.ISelection;
-import org.eclipse.mylyn.monitor.ui.AbstractUserInteractionMonitor;
+import org.eclipse.mylyn.context.core.AbstractContextInteractionMonitor;
 import org.eclipse.ui.IWorkbenchPart;
 
 /**
- * @deprecated use {@link org.eclipse.mylyn.context.sdk.util.AbstractUserInteractionMonitor} instead
+ * @deprecated use {@link org.eclipse.mylyn.context.sdk.util.AbstractContextInteractionMonitor} instead
  * @author Mik Kersten
  */
 @Deprecated
-public class TestMonitor extends AbstractUserInteractionMonitor {
+public class TestMonitor extends AbstractContextInteractionMonitor {
 
 	List<IJavaElement> selections = new ArrayList<IJavaElement>();
 

--- a/org.eclipse.mylyn.ide.ant/src/org/eclipse/mylyn/internal/ide/ant/AntEditingMonitor.java
+++ b/org.eclipse.mylyn.ide.ant/src/org/eclipse/mylyn/internal/ide/ant/AntEditingMonitor.java
@@ -21,8 +21,8 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.text.TextSelection;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.mylyn.commons.core.StatusHandler;
+import org.eclipse.mylyn.context.core.AbstractContextInteractionMonitor;
 import org.eclipse.mylyn.internal.ide.ui.XmlNodeHelper;
-import org.eclipse.mylyn.monitor.ui.AbstractUserInteractionMonitor;
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.part.FileEditorInput;
@@ -31,7 +31,7 @@ import org.eclipse.ui.part.FileEditorInput;
  * @author Mik Kersten
  */
 @SuppressWarnings("restriction")
-public class AntEditingMonitor extends AbstractUserInteractionMonitor {
+public class AntEditingMonitor extends AbstractContextInteractionMonitor {
 
 	public AntEditingMonitor() {
 		super();

--- a/org.eclipse.mylyn.java.ui/src/org/eclipse/mylyn/internal/java/ui/JavaEditingMonitor.java
+++ b/org.eclipse.mylyn.java.ui/src/org/eclipse/mylyn/internal/java/ui/JavaEditingMonitor.java
@@ -29,15 +29,15 @@ import org.eclipse.jface.text.TextSelection;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.mylyn.commons.core.StatusHandler;
+import org.eclipse.mylyn.context.core.AbstractContextInteractionMonitor;
 import org.eclipse.mylyn.internal.java.ui.search.JavaImplementorsProvider;
 import org.eclipse.mylyn.internal.java.ui.search.JavaReferencesProvider;
-import org.eclipse.mylyn.monitor.ui.AbstractUserInteractionMonitor;
 import org.eclipse.ui.IWorkbenchPart;
 
 /**
  * @author Mik Kersten
  */
-public class JavaEditingMonitor extends AbstractUserInteractionMonitor {
+public class JavaEditingMonitor extends AbstractContextInteractionMonitor {
 
 	protected IJavaElement lastSelectedElement = null;
 

--- a/org.eclipse.mylyn.pde.ui/src/org/eclipse/mylyn/internal/pde/ui/PdeEditingMonitor.java
+++ b/org.eclipse.mylyn.pde.ui/src/org/eclipse/mylyn/internal/pde/ui/PdeEditingMonitor.java
@@ -23,8 +23,8 @@ import org.eclipse.jface.text.TextSelection;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.mylyn.commons.core.StatusHandler;
+import org.eclipse.mylyn.context.core.AbstractContextInteractionMonitor;
 import org.eclipse.mylyn.internal.ide.ui.XmlNodeHelper;
-import org.eclipse.mylyn.monitor.ui.AbstractUserInteractionMonitor;
 import org.eclipse.pde.core.plugin.IPluginModelBase;
 import org.eclipse.pde.core.plugin.IPluginObject;
 import org.eclipse.pde.internal.core.plugin.ImportObject;
@@ -43,7 +43,7 @@ import org.eclipse.ui.part.FileEditorInput;
  * @author Mik Kersten
  */
 @SuppressWarnings("restriction")
-public class PdeEditingMonitor extends AbstractUserInteractionMonitor {
+public class PdeEditingMonitor extends AbstractContextInteractionMonitor {
 
 	public PdeEditingMonitor() {
 		super();

--- a/org.eclipse.mylyn.resources.ui/src/org/eclipse/mylyn/internal/resources/ui/ResourceInteractionMonitor.java
+++ b/org.eclipse.mylyn.resources.ui/src/org/eclipse/mylyn/internal/resources/ui/ResourceInteractionMonitor.java
@@ -22,15 +22,15 @@ import org.eclipse.jface.text.TextSelection;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.mylyn.commons.core.StatusHandler;
+import org.eclipse.mylyn.context.core.AbstractContextInteractionMonitor;
 import org.eclipse.mylyn.context.core.ContextCore;
-import org.eclipse.mylyn.monitor.ui.AbstractUserInteractionMonitor;
 import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.part.EditorPart;
 
 /**
  * @author Mik Kersten
  */
-public class ResourceInteractionMonitor extends AbstractUserInteractionMonitor {
+public class ResourceInteractionMonitor extends AbstractContextInteractionMonitor {
 
 	private static final String ID_SYNCHRONIZE_VIEW = "org.eclipse.team.sync.views.SynchronizeView"; //$NON-NLS-1$
 


### PR DESCRIPTION
use startup extention point (same as in org.eclipse.mylyn.context.ui) for lazy initializion

https://github.com/eclipse-mylyn/org.eclipse.mylyn.commons/issues/16